### PR TITLE
Add support for TablePlus installed via Setapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A tiny, fast, and reliable workflow for launching your saved TablePlus
 connections.
 
-At only 43 lines of code and built for Alfred 5, this should be one of the
+At only 44 lines of code and built for Alfred 5, this should be one of the
 fastest workflows for TablePlus.
 
 <https://github.com/zachahn/alfred-tableplus-workflow>

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ fastest workflows for TablePlus.
 ## Requirements
 
 * [Alfred 5](https://www.alfredapp.com) with Powerpack
-* [TablePlus](https://tableplus.com)
+* [TablePlus](https://tableplus.com) (supports both standard installation and Setapp installation)
 * Ruby, a programming language that comes built-in with every Mac
 * `plutil`, a utility that comes built-in with every Mac
+
+## Installation Methods
+
+This workflow supports TablePlus installed via:
+- **Standard installation** from the TablePlus website or Mac App Store
+- **Setapp subscription** service
+
+The workflow automatically detects which installation method you're using and finds your connections accordingly.
 
 ## See also
 

--- a/info.plist
+++ b/info.plist
@@ -153,7 +153,7 @@ main
 A tiny, fast, and reliable workflow for launching your saved TablePlus
 connections.
 
-At only 43 lines of code and built for Alfred 5, this should be one of the
+At only 44 lines of code and built for Alfred 5, this should be one of the
 fastest workflows for TablePlus.
 
 &lt;https://github.com/zachahn/alfred-tableplus-workflow&gt;
@@ -161,9 +161,17 @@ fastest workflows for TablePlus.
 ## Requirements
 
 * [Alfred 5](https://www.alfredapp.com) with Powerpack
-* [TablePlus](https://tableplus.com)
+* [TablePlus](https://tableplus.com) (supports both standard installation and Setapp installation)
 * Ruby, a programming language that comes built-in with every Mac
 * `plutil`, a utility that comes built-in with every Mac
+
+## Installation Methods
+
+This workflow supports TablePlus installed via:
+- **Standard installation** from the TablePlus website or Mac App Store
+- **Setapp subscription** service
+
+The workflow automatically detects which installation method you're using and finds your connections accordingly.
 
 ## See also
 

--- a/info.plist
+++ b/info.plist
@@ -86,6 +86,7 @@
 def main
   possible_files = [
     File.expand_path("~/Library/Application Support/com.tinyapp.TablePlus/Data/Connections.plist"),
+    File.expand_path("~/Library/Application Support/com.tinyapp.TablePlus-setapp/Data/Connections.plist"),
   ]
 
   connections_file = possible_files.find { |filepath| File.file?(filepath) }

--- a/source/README.template
+++ b/source/README.template
@@ -11,9 +11,17 @@ fastest workflows for TablePlus.
 ## Requirements
 
 * [Alfred 5](https://www.alfredapp.com) with Powerpack
-* [TablePlus](https://tableplus.com)
+* [TablePlus](https://tableplus.com) (supports both standard installation and Setapp installation)
 * Ruby, a programming language that comes built-in with every Mac
 * `plutil`, a utility that comes built-in with every Mac
+
+## Installation Methods
+
+This workflow supports TablePlus installed via:
+- **Standard installation** from the TablePlus website or Mac App Store
+- **Setapp subscription** service
+
+The workflow automatically detects which installation method you're using and finds your connections accordingly.
 
 ## See also
 

--- a/source/script.rb
+++ b/source/script.rb
@@ -3,6 +3,7 @@ require "json"
 def main
   possible_files = [
     File.expand_path("~/Library/Application Support/com.tinyapp.TablePlus/Data/Connections.plist"),
+    File.expand_path("~/Library/Application Support/com.tinyapp.TablePlus-setapp/Data/Connections.plist"),
   ]
 
   connections_file = possible_files.find { |filepath| File.file?(filepath) }


### PR DESCRIPTION
Adds support for TablePlus installed via Setapp and updates README.
Didn't realize the script was in the plist as well. My first digging into Alfred workflow. I saw the script worked and thought I was done. :)

Thanks for this btw -- I wouldn't have known where to start, and this will be very helpful.